### PR TITLE
Prepare 3.0 release

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -53,7 +53,7 @@ export class CanBridge {
     getCANDetailStatus: (descriptor:string) => CanDeviceStatus;
     sendCANMessage: (descriptor:string, messageId: number, messageData: number[], repeatPeriod: number) => number;
     sendHALMessage: (messageId: number, messageData: number[], repeatPeriod: number) => number;
-    intializeNotifier: () => void;
+    initializeNotifier: () => void;
     waitForNotifierAlarm: (time:number) => Promise<number>;
     stopNotifier: () => void;
     writeDfuToBin: (dfuFileName:string, binFileName:string) => Promise<number>;
@@ -79,7 +79,7 @@ export class CanBridge {
             this.getCANDetailStatus = addon.getCANDetailStatus;
             this.sendCANMessage = addon.sendCANMessage;
             this.sendHALMessage = addon.sendHALMessage;
-            this.intializeNotifier = addon.intializeNotifier;
+            this.initializeNotifier = addon.initializeNotifier;
             this.waitForNotifierAlarm = promisify(addon.waitForNotifierAlarm);
             this.stopNotifier = addon.stopNotifier;
             this.writeDfuToBin = promisify(addon.writeDfuToBin);

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -22,8 +22,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, sendCANMessage));
     exports.Set(Napi::String::New(env, "sendHALMessage"),
                 Napi::Function::New(env, sendHALMessage));
-    exports.Set(Napi::String::New(env, "intializeNotifier"),
-                Napi::Function::New(env, intializeNotifier));
+    exports.Set(Napi::String::New(env, "initializeNotifier"),
+                Napi::Function::New(env, initializeNotifier));
     exports.Set(Napi::String::New(env, "waitForNotifierAlarm"),
                 Napi::Function::New(env, waitForNotifierAlarm));
     exports.Set(Napi::String::New(env, "stopNotifier"),

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -606,7 +606,7 @@ void closeHALStreamSession(const Napi::CallbackInfo& info) {
     HAL_CAN_CloseStreamSession(streamHandle);
 }
 
-void intializeNotifier(const Napi::CallbackInfo& info) {
+void initializeNotifier(const Napi::CallbackInfo& info) {
     int32_t status;
     m_notifier = HAL_InitializeNotifier(&status);
 }
@@ -718,7 +718,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
     Napi::Array dataParam = info[1].As<Napi::Array>();
 
     uint8_t heartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
-    
+
     {
         std::scoped_lock lock{canDevicesMtx};
         auto deviceIterator = canDeviceMap.find(descriptor);

--- a/src/canWrapper.h
+++ b/src/canWrapper.h
@@ -14,7 +14,7 @@ Napi::Object getCANDetailStatus(const Napi::CallbackInfo& info);
 Napi::Number sendCANMessage(const Napi::CallbackInfo& info);
 Napi::Number sendCANMessageThroughHal(const Napi::CallbackInfo& info);
 Napi::Number sendHALMessage(const Napi::CallbackInfo& info);
-void intializeNotifier(const Napi::CallbackInfo& info);
+void initializeNotifier(const Napi::CallbackInfo& info);
 void waitForNotifierAlarm(const Napi::CallbackInfo& info);
 void stopNotifier(const Napi::CallbackInfo& info);
 void writeDfuToBin(const Napi::CallbackInfo& info);

--- a/test/test_binding.js
+++ b/test/test_binding.js
@@ -156,7 +156,7 @@ async function testSetThreadPriority() {
 
 function testInitializeNotifier() {
     try {
-        addon.intializeNotifier();
+        addon.initializeNotifier();
     } catch(error) {
         assert.fail(error);
     }


### PR DESCRIPTION
Moves all functions to a class, whose constructor handles loading the native addon. This way, there won't be any side effects just from importing something from this library. This makes error handling _much_ easier. To make it even better, we now throw a custom `Error` subclass that explains what to check for, and includes the original error in a field.

I also renamed a function that had a typo.