### PR TITLE
Overhaul heartbeats

### DIFF
--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -680,9 +680,15 @@ void heartbeatsWatchdog() {
             uint8_t disabledRevCommonHeartbeat[] = {0};
             for(int i = 0; i < heartbeatsRunning.size(); i++) {
                 if (sparkHeartbeatMap.contains(heartbeatsRunning[i])) {
+                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
+                    _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, disabledSparkHeartbeat, 8, -1);
+
                     _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, disabledSparkHeartbeat, 8, HEARTBEAT_PERIOD_MS);
                 }
                 if (revCommonHeartbeatMap.contains(heartbeatsRunning[i])) {
+                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
+                    _sendCANMessage(descriptor, REV_COMMON_HEARTBEAT_ID, disabledRevCommonHeartbeat, 1, -1);
+
                     _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, disabledRevCommonHeartbeat, 1, HEARTBEAT_PERIOD_MS);
                 }
             }
@@ -691,9 +697,15 @@ void heartbeatsWatchdog() {
             heartbeatTimeoutExpired = false;
             for(int i = 0; i < heartbeatsRunning.size(); i++) {
                 if (auto heartbeatEntry = sparkHeartbeatMap.find(heartbeatsRunning[i]); heartbeatEntry != sparkHeartbeatMap.end()) {
+                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
+                    _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeatEntry->second.data(), 8, -1);
+
                     _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, heartbeatEntry->second.data(), 8, HEARTBEAT_PERIOD_MS);
                 }
                 if (auto heartbeatEntry = revCommonHeartbeatMap.find(heartbeatsRunning[i]); heartbeatEntry != revCommonHeartbeatMap.end()) {
+                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
+                    _sendCANMessage(descriptor, REV_COMMON_HEARTBEAT_ID, heartbeatEntry->second.data(), 1, -1);
+
                     _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, heartbeatEntry->second.data(), 1, HEARTBEAT_PERIOD_MS);
                 }
             }

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -627,6 +627,7 @@ void waitForNotifierAlarm(const Napi::CallbackInfo& info) {
     int32_t status;
 
     HAL_UpdateNotifierAlarm(m_notifier, HAL_GetFPGATime(&status) + time, &status);
+    // TODO(Noah): Don't discard the returned value (this function is marked as [nodiscard])
     HAL_WaitForNotifierAlarm(m_notifier, &status);
     cb.Call(info.Env().Global(), {info.Env().Null(), Napi::Number::New(info.Env(), status)});
 }

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -22,6 +22,8 @@
 
 #define DEVICE_NOT_FOUND_ERROR "Device not found. Make sure to run getDevices()"
 
+#define HEARTBEAT_PERIOD_MS 20
+
 rev::usb::CandleWinUSBDriver* driver = new rev::usb::CandleWinUSBDriver();
 
 std::set<std::string> devicesRegisteredToHal; // TODO(Noah): Protect with mutex
@@ -692,7 +694,7 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
     }
 
     uint8_t payload[] = {1};
-    _sendCANMessage(descriptor, 0x00502C0, payload, 1, 20);
+    _sendCANMessage(descriptor, 0x00502C0, payload, 1, HEARTBEAT_PERIOD_MS);
 
     std::scoped_lock lock{watchdogMtx};
 
@@ -738,7 +740,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
         _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, -1);
     }
     else {
-        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, 10);
+        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, HEARTBEAT_PERIOD_MS);
 
         std::scoped_lock lock{watchdogMtx};
 

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -20,7 +20,7 @@
 #include "canWrapper.h"
 #include "DfuSeFile.h"
 
-#define DEVICE_NOT_FOUND_ERROR "Device not found.  Make sure to run getDevices()"
+#define DEVICE_NOT_FOUND_ERROR "Device not found. Make sure to run getDevices()"
 
 rev::usb::CandleWinUSBDriver* driver = new rev::usb::CandleWinUSBDriver();
 

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -648,7 +648,7 @@ void writeDfuToBin(const Napi::CallbackInfo& info) {
 
 void heartbeatsWatchdog() {
     while (true) {
-        std::this_thread::sleep_for (std::chrono::seconds(1));
+        std::this_thread::sleep_for (std::chrono::milliseconds(250));
 
         {
             // Erase removed CAN buses from heartbeatsRunning

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -37,7 +37,7 @@ std::map<std::string, std::shared_ptr<rev::usb::CANDevice>> canDeviceMap;
 
 std::mutex watchdogMtx;
 std::vector<std::string> heartbeatsRunning;
-auto latestHeartbeatAck = std::chrono::system_clock::now();
+auto latestHeartbeatAck = std::chrono::steady_clock::now();
 
 // Only call when holding canDevicesMtx
 void removeExtraDevicesFromDeviceMap(std::vector<std::string> descriptors) {
@@ -665,7 +665,7 @@ void heartbeatsWatchdog() {
 
         if (heartbeatsRunning.size() < 1) { break; }
 
-        auto now = std::chrono::system_clock::now();
+        auto now = std::chrono::steady_clock::now();
         std::chrono::duration<double> elapsed_seconds = now-latestHeartbeatAck;
         if (elapsed_seconds.count() > 1) {
             uint8_t sparkMaxHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -680,7 +680,7 @@ void heartbeatsWatchdog() {
 
 void ackHeartbeats(const Napi::CallbackInfo& info) {
     std::scoped_lock lock{watchdogMtx};
-    latestHeartbeatAck = std::chrono::system_clock::now();
+    latestHeartbeatAck = std::chrono::steady_clock::now();
 }
 
 // Params:
@@ -702,7 +702,7 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
 
     if (heartbeatsRunning.size() == 0) {
         heartbeatsRunning.push_back(descriptor);
-        latestHeartbeatAck = std::chrono::system_clock::now();
+        latestHeartbeatAck = std::chrono::steady_clock::now();
         std::thread hb(heartbeatsWatchdog);
         hb.detach();
     } else {
@@ -748,7 +748,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
 
         if (heartbeatsRunning.size() == 0) {
             heartbeatsRunning.push_back(descriptor);
-            latestHeartbeatAck = std::chrono::system_clock::now();
+            latestHeartbeatAck = std::chrono::steady_clock::now();
             std::thread hb(heartbeatsWatchdog);
             hb.detach();
         } else {

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -22,6 +22,8 @@
 
 #define DEVICE_NOT_FOUND_ERROR "Device not found. Make sure to run getDevices()"
 
+#define REV_COMMON_HEARTBEAT_ID 0x00502C0
+#define SPARK_HEARTBEAT_ID 0x2052C80
 #define HEARTBEAT_PERIOD_MS 20
 
 rev::usb::CandleWinUSBDriver* driver = new rev::usb::CandleWinUSBDriver();
@@ -669,8 +671,8 @@ void heartbeatsWatchdog() {
             uint8_t sparkMaxHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
             uint8_t revCommonHeartbeat[] = {0};
             for(int i = 0; i < heartbeatsRunning.size(); i++) {
-                _sendCANMessage(heartbeatsRunning[i], 0x2052C80, sparkMaxHeartbeat, 8, -1);
-                _sendCANMessage(heartbeatsRunning[i], 0x00502C0, revCommonHeartbeat, 1, -1);
+                _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, sparkMaxHeartbeat, 8, -1);
+                _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, revCommonHeartbeat, 1, -1);
             }
         }
     }
@@ -694,7 +696,7 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
     }
 
     uint8_t payload[] = {1};
-    _sendCANMessage(descriptor, 0x00502C0, payload, 1, HEARTBEAT_PERIOD_MS);
+    _sendCANMessage(descriptor, REV_COMMON_HEARTBEAT_ID, payload, 1, HEARTBEAT_PERIOD_MS);
 
     std::scoped_lock lock{watchdogMtx};
 
@@ -727,7 +729,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
         if (deviceIterator == canDeviceMap.end()) return;
     }
 
-    _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, -1);
+    _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat, 8, -1);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     int sum = 0;
@@ -737,10 +739,10 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
     }
 
     if (sum == 0) {
-        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, -1);
+        _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat, 8, -1);
     }
     else {
-        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, HEARTBEAT_PERIOD_MS);
+        _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat, 8, HEARTBEAT_PERIOD_MS);
 
         std::scoped_lock lock{watchdogMtx};
 

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -729,8 +729,8 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
         if (deviceIterator == canDeviceMap.end()) return;
     }
 
+    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
     _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat, 8, -1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     int sum = 0;
     for (uint32_t i = 0; i < dataParam.Length(); i++) {


### PR DESCRIPTION
* When the latest heartbeat ack expires, immediately start sending disabled heartbeats instead of just canceling the heartbeats
* Don't start heartbeats while the heartbeat ack timeout is expired
	* If the application attempts to do this, the heartbeat will not be started until after the next heartbeat ack is received.
* Check for expired heartbeat acks every 250ms instead of 1000ms
* Use `steady_clock` instead of `system_clock`
* Increase the SPARK heartbeat period from 10ms to 20ms (same as the REV common heartbeat)