### PR TITLE
node-can-bridge: Add support for Linux and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: "Build - ${{ matrix.os }}"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install Python setup tools
+      run: |
+          pip install setuptools
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Test
+      run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Install dependencies
       run: npm install
 
-    - name: Build
-      run: npm run build
+    - name: Pretest
+      run: npm run pretest
 
     - name: Test
       run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: "Release - ${{ matrix.os }}"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install Python setup tools
+      run: |
+          pip install setuptools
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Create release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+        tag_name: ${{ github.ref }}
+        name: ${{ github.ref }}
+        body: |
+          This is a release for version ${{ github.ref }}.
+          It contains the compiled files from the build process.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 This package enables Node.js applications to use a CAN bus over USB.
 
-## Making a release
+## Compiling
+
+### Prerequisites
+
+- Supported version of NodeJS (preferably a LTS version)
+- A C/C++ compiler that supports C++20
+- Internet connection to pull from upstream [CANBridge](https://github.com/unofficial-rev-port/CANBridge)
+
+### Steps
+
+1. Clone repository
+2. Run `npm i` to install dependencies and compile the Node APIs
+3. To test, run `npm run pretest` to prepare the testing and `npm test` to actually perform the testing of the repository
+
+## Making a release (for repository owners)
 
 1. Check out the `main` branch
 2. Update `version` field in `package.json`
@@ -10,6 +24,6 @@ This package enables Node.js applications to use a CAN bus over USB.
 4. Commit change to git
 5. Run `git tag v<version>`
 6. Run `git push`
-7. Run `git push --tags` 
+7. Run `git push --tags`
 8. Run `npm publish --access public`
 9. Create a new release on GitHub with an explanation of the changes

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       'sources': [
         'src/addon.cc',
         'src/canWrapper.cc',
-       ],
+      ],
       'include_dirs': [
         "src/",
         "externalCompileTimeDeps/include",
@@ -15,21 +15,46 @@
         "NAPI_VERSION=<(napi_build_version)"
       ],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
-      'libraries': [
-            # These files were placed by download-CanBridge.mjs
-            '<(module_root_dir)/externalCompileTimeDeps/CANBridge.lib',
-            '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
-            '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
+      'conditions': [
+        ['OS=="mac"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/libCANBridge.a',
+            ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/darwin-x64/libCANBridge.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiHal.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiutil.dylib',
+                ]
+            }],
+        }],
+        ['OS=="win"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/CANBridge.lib',
+                '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
+                '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
+            ],
+        }],
+        ['OS=="linux"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/libCANBridge.a',
+            ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/linux-x64/libCANBridge.so',
+                    '<(module_root_dir)/prebuilds/linux-x64/libwpiHal.so',
+                    '<(module_root_dir)/prebuilds/linux-x64/libwpiutil.so',
+                ]
+            }],
+        }],
       ],
-      'copies': [{
-        'destination': './build/Release',
-        'files': [
-          # These files were placed in the prebuilds folder by download-CanBridge.mjs
-          '<(module_root_dir)/prebuilds/win32-x64/CANBridge.dll',
-          '<(module_root_dir)/prebuilds/win32-x64/wpiHal.dll',
-          '<(module_root_dir)/prebuilds/win32-x64/wpiutil.dll',
-        ]
-      }],
       'msvs_settings': {
         'VCCLCompilerTool': {
             'ExceptionHandling': 1,

--- a/binding.gyp
+++ b/binding.gyp
@@ -66,8 +66,8 @@
           "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
           "OTHER_CPLUSPLUSFLAGS": ["-fexceptions"]
       },
-      "cflags_cc!": ["-std=c++20", '-fno-exceptions'],
-      "cflags!": ["-std=c++20", '-fno-exceptions'],
+      "cflags_cc": ["-std=c++20", '-fexceptions'],
+      "cflags": ["-std=c++20", '-fexceptions'],
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,15 @@
                 '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
                 '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
             ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/win32-x64/CANBridge.dll',
+                    '<(module_root_dir)/prebuilds/win32-x64/wpiHal.dll',
+                    '<(module_root_dir)/prebuilds/win32-x64/wpiutil.dll',
+                ]
+            }],
         }],
         ['OS=="linux"', {
             'libraries': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,6 +37,10 @@
             'RuntimeLibrary': 0
         },
       },
+      "xcode_settings": {
+          "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
+          "OTHER_CPLUSPLUSFLAGS": ["-fexceptions"]
+      },
       "cflags_cc!": ["-std=c++20", '-fno-exceptions'],
       "cflags!": ["-std=c++20", '-fno-exceptions'],
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -25,9 +25,9 @@
                 'destination': './build/Release',
                 'files': [
                     # These files were placed in the prebuilds folder by download-CanBridge.mjs
-                    '<(module_root_dir)/prebuilds/darwin-x64/libCANBridge.dylib',
-                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiHal.dylib',
-                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiutil.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-osxuniversal/libCANBridge.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-osxuniversal/libwpiHal.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-osxuniversal/libwpiutil.dylib',
                 ]
             }],
         }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -73,7 +73,10 @@
       },
       "xcode_settings": {
           "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
-          "OTHER_CPLUSPLUSFLAGS": ["-fexceptions"]
+          'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'GCC_ENABLE_CPP_RTTI': 'YES',
+          "OTHER_CPLUSPLUSFLAGS": ["-fexceptions"],
+          # 'MACOSX_DEPLOYMENT_TARGET': '14.0',
       },
       "cflags_cc": ["-std=c++20", '-fexceptions'],
       "cflags": ["-std=c++20", '-fexceptions'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@rev-robotics/can-bridge",
-    "version": "3.2.0",
+    "version": "3.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@rev-robotics/can-bridge",
-            "version": "3.2.0",
+            "version": "3.2.6",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "install": "node-gyp-build \"node scripts/download-CanBridge.mjs\"",
+        "install": "node scripts/download-CanBridge.mjs && node-gyp rebuild",
         "prepublishOnly": "node scripts/download-CanBridge.mjs && tsc && prebuildify --napi",
-        "pretest": "node-gyp-build && tsc",
+        "pretest": "node-gyp rebuild && tsc",
         "test": "node --napi-modules test/test_binding.js"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rev-robotics/can-bridge",
-    "version": "3.2.0",
+    "version": "3.2.6",
     "author": "REV Robotics",
     "description": "Access CAN Data from a USB device in Node.js",
     "license": "MIT",

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,7 +4,7 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 
 const canBridgeTag = "v2.3.0";
-const canBridgeReleaseAssetUrlPrefix = `https://github.com/REVrobotics/CANBridge/releases/download/${canBridgeTag}`;
+const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
 const runtimeArtifactsPath = path.join('prebuilds', 'win32-x64');

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -2,47 +2,128 @@ import * as fs from "fs";
 import * as path from "path";
 import axios from 'axios';
 import AdmZip from 'adm-zip';
+import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.0";
+const canBridgeTag = "v2.3.1";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
-const runtimeArtifactsPath = path.join('prebuilds', 'win32-x64');
+const runtimeArtifactsPath = {
+    win: 'prebuilds/win32-x64',
+    osx: 'prebuilds/darwin-x64',
+    osxArm: 'prebuilds/darwin-arm64',
+    linux: 'prebuilds/linux-x64',
+    linuxArm: 'prebuilds/linux-arm64',
+    linuxArm32: 'prebuilds/linux-arm32'
+};
 const tempDir = 'temp';
 
 try {
-    await Promise.all(Array.of(
-        downloadCanBridgeArtifact('CANBridge.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('CANBridge.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('wpiHal.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('wpiHal.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('wpiutil.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('wpiutil.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('headers.zip', tempDir),
-    ));
-
+    // TODO: Do not hardcode the filenames, instead get them from the GitHub API -> Look at Octokit: https://github.com/octokit/octokit.js
+    await Promise.all([
+        'CANBridge-linuxarm32-LinuxARM32.zip',
+        'CANBridge-linuxarm64-LinuxARM64.zip',
+        'CANBridge-linuxx86-64-Linux64.zip',
+        'CANBridge-osxuniversal-MacOS64.zip',
+        'CANBridge-osxuniversal-MacOSARM64.zip',
+        'CANBridge-windowsx86-64-Win64.zip',
+        'headers.zip'
+    ].map(filename => downloadCanBridgeArtifact(filename)));
     console.log("CANBridge download completed");
+
+    
     console.log("Extracting headers");
-
+    const zipFiles = fs.readdirSync(tempDir).filter(filename => filename.endsWith('.zip') && filename !== 'headers.zip');
+    for (const filename of zipFiles) { 
+        await unzipCanBridgeArtifact(filename, tempDir);
+    }
     const headersZip = new AdmZip(path.join(tempDir, "headers.zip"));
+    headersZip.extractAllTo(path.join(externalCompileTimeDepsPath, 'include'));
+    console.log("Headers extracted");
 
-    await headersZip.extractAllTo(path.join(externalCompileTimeDepsPath, 'include'));
+    moveRuntimeDeps();
+
+    moveCompileTimeDeps();
 } catch (e) {
     if (axios.isAxiosError(e) && e.request) {
-        console.error(`Failed to download CANBridge file ${e.request.protocol}//${e.request.host}/${e.request.path}`);
+        console.error(`Failed to download CANBridge file ${e.request.protocol}//${e.request.host}${e.request.path}`);
     } else {
-        console.error(`Failed to download CANBridge`);
+        console.error(`Other error occurred: ${e.message}`);
         // For non-axios errors, the stacktrace will likely be helpful
         throw e;
     }
     process.exit(1);
 } finally {
     if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true });
+        fs.rmSync(tempDir, { recursive: true, force: true});
     }
 }
 
-async function downloadCanBridgeArtifact(filename, destDir) {
+/**
+ * Move external compile time dependencies to the correct directory
+ * 
+ * This function is used to move the external compile time dependencies to the correct directory based on the platform and architecture from downloaded artifacts
+ */
+function moveCompileTimeDeps() {
+    console.log("Moving external compile time dependencies to correct directories");
+    if (platform() === 'win32') {
+        const deps = ['CANBridge.lib', 'wpiHal.lib', 'wpiutil.lib'];
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
+    } else if (platform() === 'darwin') {
+        const deps = ['libCANBridge.a'];
+        const archDepMap = {
+            x64: 'darwin-x64',
+            arm64: 'darwin-arm64'
+        };
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+    } else if (platform() === 'linux') {
+        const deps = ['libCANBridge.a'];
+        const archDepMap = {
+            x64: 'linux-x64',
+            arm64: 'linux-arm64',
+            arm: 'linux-arm32'
+        };
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+    }
+    console.log("External compile time dependencies moved to correct directories");
+}
+
+/**
+ * Move runtime dependencies to the correct directory
+ * 
+ * This function is used to move the runtime dependencies to the correct directory based on the platform and architecture from downloaded artifacts
+ */
+function moveRuntimeDeps() {
+    console.log("Moving artifacts to correct directories");
+    if (platform() === 'win32') {
+        const deps = ['CANBridge.dll', 'wpiHal.dll', 'wpiutil.dll'];
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
+    } else if (platform() === 'darwin') {
+        const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
+        const archDepMap = {
+            x64: runtimeArtifactsPath.osx,
+            arm64: runtimeArtifactsPath.osxArm
+        };
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+    } else if (platform() === 'linux') {
+        const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
+        const archDepMap = {
+            x64: runtimeArtifactsPath.linux,
+            arm64: runtimeArtifactsPath.linuxArm,
+            arm: runtimeArtifactsPath.linuxArm32
+        };
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+    }
+    console.log("CANBridge artifacts moved to correct directories");
+}
+
+/**
+ * Download artifacts from the CANBridge GitHub release page
+ * 
+ * @param {*} filename filename of the artifact to download
+ * @param {*} destDir destination directory to save the artifact, defaults to tempDir
+ */
+async function downloadCanBridgeArtifact(filename, destDir = tempDir) {
     fs.mkdirSync(destDir, { recursive: true });
     const response = await axios.get(`${canBridgeReleaseAssetUrlPrefix}/${filename}`, { responseType: "stream" });
     const fileStream = fs.createWriteStream(`${destDir}/${filename}`);
@@ -50,4 +131,42 @@ async function downloadCanBridgeArtifact(filename, destDir) {
     await new Promise(resolve => {
         fileStream.on('finish', resolve);
     });
+}
+
+/**
+ * Unzip the CANBridge artifacts
+ * 
+ * @param {string} filename - filename of the artifact to unzip
+ * @param {string} destDir - destination directory to unzip the artifact
+ */
+async function unzipCanBridgeArtifact(filename, destDir) {
+    const zip = new AdmZip(`${destDir}/${filename}`);
+    let filepath;
+    if (filename.includes('linuxarm32')) filepath = "linux-arm32";
+    else if (filename.includes('linuxarm64')) filepath = "linux-arm64";
+    else if (filename.includes('linuxx86-64')) filepath = "linux-x64";
+    else if (filename.includes('MacOS64')) filepath = "darwin-x64";
+    else if (filename.includes('MacOSARM64')) filepath = "darwin-arm64";
+    else if (filename.includes('windowsx86-64')) filepath = "win32-x64";
+    zip.extractAllTo(`${destDir}/${filepath}`);
+}
+
+/**
+ * Move runtime artifacts to the correct directory
+ * 
+ * @param {*} filename filename of the artifact to move
+ * @param {*} destDir destination directory to save the artifact
+ */
+function moveRuntimeArtifactsDeps(filename, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.renameSync(path.join(tempDir, filename), path.join(destDir, path.basename(filename)));
+}
+
+/**
+ * Move External Compile Time Dependencies to the correct directory
+ * 
+ * @param {*} filename filename of the artifact to move
+ */
+function moveExternalCompileTimeDeps(filename) {
+    fs.renameSync(path.join(tempDir, filename), path.join(externalCompileTimeDepsPath, path.basename(filename)));
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -54,9 +54,9 @@ try {
     }
     process.exit(1);
 } finally {
-    if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true});
-    }
+    //if (fs.existsSync(tempDir)) {
+    //    fs.rmSync(tempDir, { recursive: true, force: true});
+    //}
 }
 
 /**
@@ -66,6 +66,9 @@ try {
  */
 function moveCompileTimeDeps() {
     console.log("Moving external compile time dependencies to correct directories");
+    if (!fs.existsSync(externalCompileTimeDepsPath)) {
+        fs.mkdirSync(externalCompileTimeDepsPath, { recursive: true });
+    }
     if (platform() === 'win32') {
         const deps = ['CANBridge.lib', 'wpiHal.lib', 'wpiutil.lib'];
         deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
@@ -95,24 +98,31 @@ function moveCompileTimeDeps() {
  */
 function moveRuntimeDeps() {
     console.log("Moving artifacts to correct directories");
+    if (!fs.existsSync('prebuilds')) {
+        fs.mkdirSync('prebuilds', { recursive: true });
+    }
     if (platform() === 'win32') {
         const deps = ['CANBridge.dll', 'wpiHal.dll', 'wpiutil.dll'];
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        const archDepMap = {
-            x64: runtimeArtifactsPath.osx,
-            arm64: runtimeArtifactsPath.osxArm
-        };
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+        if (arch() === 'x64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
+        }
+        if (arch() === 'arm64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-arm64', dep), runtimeArtifactsPath.osxArm));
+        }
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
-        const archDepMap = {
-            x64: runtimeArtifactsPath.linux,
-            arm64: runtimeArtifactsPath.linuxArm,
-            arm: runtimeArtifactsPath.linuxArm32
-        };
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+        if (arch() === 'x64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-x64', dep), runtimeArtifactsPath.linux));
+        }
+        if (arch() === 'arm64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-arm64', dep), runtimeArtifactsPath.linuxArm));
+        }
+        if (arch() === 'arm') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-arm32', dep), runtimeArtifactsPath.linuxArm32));
+        }
     }
     console.log("CANBridge artifacts moved to correct directories");
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,14 +4,13 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.1";
+const canBridgeTag = "v2.3.2";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
 const runtimeArtifactsPath = {
     win: 'prebuilds/win32-x64',
-    osx: 'prebuilds/darwin-x64',
-    osxArm: 'prebuilds/darwin-arm64',
+    osx: 'prebuilds/darwin-osxuniversal',
     linux: 'prebuilds/linux-x64',
     linuxArm: 'prebuilds/linux-arm64',
     linuxArm32: 'prebuilds/linux-arm32'
@@ -21,11 +20,10 @@ const tempDir = 'temp';
 try {
     // TODO: Do not hardcode the filenames, instead get them from the GitHub API -> Look at Octokit: https://github.com/octokit/octokit.js
     await Promise.all([
-        'CANBridge-linuxarm32-LinuxARM32.zip',
-        'CANBridge-linuxarm64-LinuxARM64.zip',
+        'CANBridge-linuxarm32.zip',
+        'CANBridge-linuxarm64.zip',
         'CANBridge-linuxx86-64-Linux64.zip',
-        'CANBridge-osxuniversal-MacOS64.zip',
-        'CANBridge-osxuniversal-MacOSARM64.zip',
+        'CANBridge-osxuniversal-macOS.zip',
         'CANBridge-windowsx86-64-Win64.zip',
         'headers.zip'
     ].map(filename => downloadCanBridgeArtifact(filename)));
@@ -74,11 +72,7 @@ function moveCompileTimeDeps() {
         deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.a'];
-        const archDepMap = {
-            x64: 'darwin-x64',
-            arm64: 'darwin-arm64'
-        };
-        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join('darwin-osxuniversal', dep)));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.a'];
         const archDepMap = {
@@ -106,7 +100,7 @@ function moveRuntimeDeps() {
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-osxuniversal', dep), runtimeArtifactsPath.osx));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
         if (arch() === 'x64') {
@@ -150,8 +144,7 @@ async function unzipCanBridgeArtifact(filename, destDir) {
     if (filename.includes('linuxarm32')) filepath = "linux-arm32";
     else if (filename.includes('linuxarm64')) filepath = "linux-arm64";
     else if (filename.includes('linuxx86-64')) filepath = "linux-x64";
-    else if (filename.includes('MacOS64')) filepath = "darwin-x64";
-    else if (filename.includes('MacOSARM64')) filepath = "darwin-arm64";
+    else if (filename.includes('osxuniversal')) filepath = "darwin-osxuniversal";
     else if (filename.includes('windowsx86-64')) filepath = "win32-x64";
     zip.extractAllTo(`${destDir}/${filepath}`);
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -106,12 +106,7 @@ function moveRuntimeDeps() {
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        if (arch() === 'x64') {
-            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
-        }
-        if (arch() === 'arm64') {
-            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-arm64', dep), runtimeArtifactsPath.osxArm));
-        }
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
         if (arch() === 'x64') {

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,7 +4,7 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.2";
+const canBridgeTag = "v2.3.3";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,7 +4,7 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.3";
+const canBridgeTag = "v2.3.6";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -768,3 +768,11 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
     }
 }
 
+/**
+ * This function was removed from commit b0ca096624286b1e975eaaa816e38599933b7e84, which broke MSVC builds.
+ * It has been re-added here to fix the build.
+ */
+void stopHeartbeats(const Napi::CallbackInfo& info) {
+    //! TODO: Reimplement this function with current codebase
+    Napi::Env env = info.Env();
+}

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -239,7 +239,7 @@ Napi::Object receiveMessage(const Napi::CallbackInfo& info) {
     size_t messageSize = message->GetSize();
     const uint8_t* messageData = message->GetData();
     Napi::Array napiMessage = Napi::Array::New(env, messageSize);
-    for (int i = 0; i < messageSize; i++) {
+    for (size_t i = 0; i < messageSize; i++) {
         napiMessage[i] =  messageData[i];
     }
     Napi::Object messageInfo = Napi::Object::New(env);
@@ -332,7 +332,7 @@ Napi::Number openStreamSession(const Napi::CallbackInfo& info) {
     try {
         rev::usb::CANStatus status = device->OpenStreamSession(&sessionHandle, filter, maxSize);
         if (status != rev::usb::CANStatus::kOk) {
-            Napi::Error::New(env, "Opening stream session failed with error code "+(int)status).ThrowAsJavaScriptException();
+            Napi::Error::New(env, "Opening stream session failed with error code "+std::to_string((int)status)).ThrowAsJavaScriptException();
         } else {
             return Napi::Number::New(env, sessionHandle);
         }
@@ -661,7 +661,7 @@ void heartbeatsWatchdog() {
         {
             // Erase removed CAN buses from heartbeatsRunning
             std::scoped_lock lock{watchdogMtx, canDevicesMtx};
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 auto deviceIterator = canDeviceMap.find(heartbeatsRunning[i]);
                 if (deviceIterator == canDeviceMap.end()) {
                     heartbeatsRunning.erase(heartbeatsRunning.begin() + i);
@@ -678,7 +678,7 @@ void heartbeatsWatchdog() {
         if (elapsed_seconds.count() > 1) {
             uint8_t sparkMaxHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
             uint8_t revCommonHeartbeat[] = {0};
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 _sendCANMessage(heartbeatsRunning[i], 0x2052C80, sparkMaxHeartbeat, 8, -1);
                 _sendCANMessage(heartbeatsRunning[i], 0x00502C0, revCommonHeartbeat, 1, -1);
             }
@@ -714,7 +714,7 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
         std::thread hb(heartbeatsWatchdog);
         hb.detach();
     } else {
-        for(int i = 0; i < heartbeatsRunning.size(); i++) {
+        for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
             if (heartbeatsRunning[i].compare(descriptor) == 0) return;
         }
         heartbeatsRunning.push_back(descriptor);
@@ -760,7 +760,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
             std::thread hb(heartbeatsWatchdog);
             hb.detach();
         } else {
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 if (heartbeatsRunning[i].compare(descriptor) == 0) return;
             }
             heartbeatsRunning.push_back(descriptor);

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -3,8 +3,15 @@
 #include <rev/CANMessage.h>
 #include <rev/CANStatus.h>
 #include <rev/CANBridgeUtils.h>
+#ifdef _WIN32
 #include <rev/Drivers/CandleWinUSB/CandleWinUSBDriver.h>
 #include <rev/Drivers/CandleWinUSB/CandleWinUSBDevice.h>
+#else
+
+#include "rev/Drivers/SerialPort/SerialDriver.h"
+#endif
+
+
 #include <utils/ThreadUtils.h>
 #include <hal/HAL.h>
 #include <hal/CAN.h>
@@ -12,7 +19,6 @@
 #include <thread>
 #include <chrono>
 #include <map>
-#include <array>
 #include <vector>
 #include <set>
 #include <exception>
@@ -21,34 +27,25 @@
 #include "canWrapper.h"
 #include "DfuSeFile.h"
 
-#define DEVICE_NOT_FOUND_ERROR "Device not found. Make sure to run getDevices()"
+#define DEVICE_NOT_FOUND_ERROR "Device not found.  Make sure to run getDevices()"
 
-#define REV_COMMON_HEARTBEAT_ID 0x00502C0
-#define SPARK_HEARTBEAT_ID 0x2052C80
-#define HEARTBEAT_PERIOD_MS 20
-
-#define SPARK_HEARTBEAT_LENGTH 8
-#define REV_COMMON_HEARTBEAT_LENGTH 1
-uint8_t disabledSparkHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
-uint8_t disabledRevCommonHeartbeat[] = {0};
-
-rev::usb::CandleWinUSBDriver* driver = new rev::usb::CandleWinUSBDriver();
+rev::usb::CANDriver* driver = 
+#ifdef _WIN32
+    new rev::usb::CandleWinUSBDriver();
+#else
+    new rev::usb::SerialDriver();
+#endif
 
 std::set<std::string> devicesRegisteredToHal; // TODO(Noah): Protect with mutex
 bool halInitialized = false;
 uint32_t m_notifier;
 
 std::mutex canDevicesMtx;
-// These values should only be accessed while holding canDevicesMtx
 std::map<std::string, std::shared_ptr<rev::usb::CANDevice>> canDeviceMap;
 
 std::mutex watchdogMtx;
-// These values should only be accessed while holding watchdogMtx
 std::vector<std::string> heartbeatsRunning;
-bool heartbeatTimeoutExpired = false; // Should only be changed in heartbeatsWatchdog()
-std::map<std::string, std::array<uint8_t, REV_COMMON_HEARTBEAT_LENGTH>> revCommonHeartbeatMap;
-std::map<std::string, std::array<uint8_t, SPARK_HEARTBEAT_LENGTH>> sparkHeartbeatMap;
-auto latestHeartbeatAck = std::chrono::steady_clock::now();
+auto latestHeartbeatAck = std::chrono::system_clock::now();
 
 // Only call when holding canDevicesMtx
 void removeExtraDevicesFromDeviceMap(std::vector<std::string> descriptors) {
@@ -632,7 +629,6 @@ void waitForNotifierAlarm(const Napi::CallbackInfo& info) {
     int32_t status;
 
     HAL_UpdateNotifierAlarm(m_notifier, HAL_GetFPGATime(&status) + time, &status);
-    // TODO(Noah): Don't discard the returned value (this function is marked as [nodiscard])
     HAL_WaitForNotifierAlarm(m_notifier, &status);
     cb.Call(info.Env().Global(), {info.Env().Null(), Napi::Number::New(info.Env(), status)});
 }
@@ -658,62 +654,33 @@ void writeDfuToBin(const Napi::CallbackInfo& info) {
     cb.Call(info.Env().Global(), {info.Env().Null(), Napi::Number::New(info.Env(), status)});
 }
 
-void cleanupHeartbeatsRunning() {
-    // Erase removed CAN buses from heartbeatsRunning
-    std::scoped_lock lock{watchdogMtx, canDevicesMtx};
-    for(int i = 0; i < heartbeatsRunning.size(); i++) {
-        auto deviceIterator = canDeviceMap.find(heartbeatsRunning[i]);
-        if (deviceIterator == canDeviceMap.end()) {
-            heartbeatsRunning.erase(heartbeatsRunning.begin() + i);
-        }
-    }
-}
-
 void heartbeatsWatchdog() {
     while (true) {
-        std::this_thread::sleep_for (std::chrono::milliseconds(250));
+        std::this_thread::sleep_for (std::chrono::seconds(1));
 
-        cleanupHeartbeatsRunning();
+        {
+            // Erase removed CAN buses from heartbeatsRunning
+            std::scoped_lock lock{watchdogMtx, canDevicesMtx};
+            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+                auto deviceIterator = canDeviceMap.find(heartbeatsRunning[i]);
+                if (deviceIterator == canDeviceMap.end()) {
+                    heartbeatsRunning.erase(heartbeatsRunning.begin() + i);
+                }
+            }
+        }
 
         std::scoped_lock lock{watchdogMtx};
 
         if (heartbeatsRunning.size() < 1) { break; }
 
-        auto now = std::chrono::steady_clock::now();
+        auto now = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = now-latestHeartbeatAck;
-        if (elapsed_seconds.count() >= 1 && !heartbeatTimeoutExpired) {
-            // The heartbeat timeout just expired
-            heartbeatTimeoutExpired = true;
+        if (elapsed_seconds.count() > 1) {
+            uint8_t sparkMaxHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
+            uint8_t revCommonHeartbeat[] = {0};
             for(int i = 0; i < heartbeatsRunning.size(); i++) {
-                if (sparkHeartbeatMap.contains(heartbeatsRunning[i])) {
-                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
-                    _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, disabledSparkHeartbeat, SPARK_HEARTBEAT_LENGTH, -1);
-
-                    _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, disabledSparkHeartbeat, SPARK_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
-                }
-                if (revCommonHeartbeatMap.contains(heartbeatsRunning[i])) {
-                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
-                    _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, disabledRevCommonHeartbeat, REV_COMMON_HEARTBEAT_LENGTH, -1);
-
-                    _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, disabledRevCommonHeartbeat, REV_COMMON_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
-                }
-            }
-        } else if (elapsed_seconds.count() < 1 && heartbeatTimeoutExpired) {
-            // The heartbeat timeout is newly un-expired
-            heartbeatTimeoutExpired = false;
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
-                if (auto heartbeatEntry = sparkHeartbeatMap.find(heartbeatsRunning[i]); heartbeatEntry != sparkHeartbeatMap.end()) {
-                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
-                    _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, heartbeatEntry->second.data(), SPARK_HEARTBEAT_LENGTH, -1);
-
-                    _sendCANMessage(heartbeatsRunning[i], SPARK_HEARTBEAT_ID, heartbeatEntry->second.data(), SPARK_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
-                }
-                if (auto heartbeatEntry = revCommonHeartbeatMap.find(heartbeatsRunning[i]); heartbeatEntry != revCommonHeartbeatMap.end()) {
-                    // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
-                    _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, heartbeatEntry->second.data(), REV_COMMON_HEARTBEAT_LENGTH, -1);
-
-                    _sendCANMessage(heartbeatsRunning[i], REV_COMMON_HEARTBEAT_ID, heartbeatEntry->second.data(), REV_COMMON_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
-                }
+                _sendCANMessage(heartbeatsRunning[i], 0x2052C80, sparkMaxHeartbeat, 8, -1);
+                _sendCANMessage(heartbeatsRunning[i], 0x00502C0, revCommonHeartbeat, 1, -1);
             }
         }
     }
@@ -721,7 +688,7 @@ void heartbeatsWatchdog() {
 
 void ackHeartbeats(const Napi::CallbackInfo& info) {
     std::scoped_lock lock{watchdogMtx};
-    latestHeartbeatAck = std::chrono::steady_clock::now();
+    latestHeartbeatAck = std::chrono::system_clock::now();
 }
 
 // Params:
@@ -736,19 +703,14 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
         if (deviceIterator == canDeviceMap.end()) return;
     }
 
-    std::array<uint8_t, REV_COMMON_HEARTBEAT_LENGTH> payload = {1};
+    uint8_t payload[] = {1};
+    _sendCANMessage(descriptor, 0x00502C0, payload, 1, 20);
 
     std::scoped_lock lock{watchdogMtx};
 
-    if (!heartbeatTimeoutExpired) {
-        _sendCANMessage(descriptor, REV_COMMON_HEARTBEAT_ID, payload.data(), REV_COMMON_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
-    }
-
-    revCommonHeartbeatMap[descriptor] = payload;
-
     if (heartbeatsRunning.size() == 0) {
         heartbeatsRunning.push_back(descriptor);
-        latestHeartbeatAck = std::chrono::steady_clock::now();
+        latestHeartbeatAck = std::chrono::system_clock::now();
         std::thread hb(heartbeatsWatchdog);
         hb.detach();
     } else {
@@ -767,7 +729,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
     std::string descriptor = info[0].As<Napi::String>().Utf8Value();
     Napi::Array dataParam = info[1].As<Napi::Array>();
 
-    std::array<uint8_t, SPARK_HEARTBEAT_LENGTH> heartbeat = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t heartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
 
     {
         std::scoped_lock lock{canDevicesMtx};
@@ -775,45 +737,34 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
         if (deviceIterator == canDeviceMap.end()) return;
     }
 
+    _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, -1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
     int sum = 0;
     for (uint32_t i = 0; i < dataParam.Length(); i++) {
         heartbeat[i] = dataParam.Get(i).As<Napi::Number>().Uint32Value();
         sum+= heartbeat[i];
     }
 
-    std::scoped_lock lock{watchdogMtx};
-
-    if (!heartbeatTimeoutExpired) {
-        // Clear the scheduled heartbeat that has outdated data so that the updated one gets sent out immediately
-        _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat.data(), SPARK_HEARTBEAT_LENGTH, -1);
-
-        _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, heartbeat.data(), SPARK_HEARTBEAT_LENGTH, HEARTBEAT_PERIOD_MS);
+    if (sum == 0) {
+        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, -1);
     }
+    else {
+        _sendCANMessage(descriptor, 0x2052C80, heartbeat, 8, 10);
 
-    sparkHeartbeatMap[descriptor] = heartbeat;
+        std::scoped_lock lock{watchdogMtx};
 
-    if (heartbeatsRunning.size() == 0) {
-        heartbeatsRunning.push_back(descriptor);
-        latestHeartbeatAck = std::chrono::steady_clock::now();
-        std::thread hb(heartbeatsWatchdog);
-        hb.detach();
-    } else {
-        for(int i = 0; i < heartbeatsRunning.size(); i++) {
-            if (heartbeatsRunning[i].compare(descriptor) == 0) return;
+        if (heartbeatsRunning.size() == 0) {
+            heartbeatsRunning.push_back(descriptor);
+            latestHeartbeatAck = std::chrono::system_clock::now();
+            std::thread hb(heartbeatsWatchdog);
+            hb.detach();
+        } else {
+            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+                if (heartbeatsRunning[i].compare(descriptor) == 0) return;
+            }
+            heartbeatsRunning.push_back(descriptor);
         }
-        heartbeatsRunning.push_back(descriptor);
     }
 }
 
-void stopHeartbeats(const Napi::CallbackInfo& info) {
-    std::string descriptor = info[0].As<Napi::String>().Utf8Value();
-    bool sendDisabledHeartbeatsFirst = info[1].As<Napi::Boolean>().Value();
-
-    // 0 sends and then cancels, -1 cancels without sending
-    const int repeatPeriod = sendDisabledHeartbeatsFirst ? 0 : -1;
-
-    std::scoped_lock lock{watchdogMtx};
-    // Send disabled SPARK and REV common heartbeats and un-schedule them for the future
-    _sendCANMessage(descriptor, SPARK_HEARTBEAT_ID, disabledSparkHeartbeat, SPARK_HEARTBEAT_LENGTH, repeatPeriod);
-    _sendCANMessage(descriptor, REV_COMMON_HEARTBEAT_ID, disabledRevCommonHeartbeat, REV_COMMON_HEARTBEAT_LENGTH, repeatPeriod);
-}


### PR DESCRIPTION
The @unofficial-rev-port team has been hard at work making the core technologies used by the REV Hardware Client work on all 3 major platforms (Windows, macOS, Linux).  This PR contains changes needed for node-can-bridge to compile and run on macOS and Linux in addition to Windows, including the changes to pull the OS-specific binaries from CANBridge (see https://github.com/REVrobotics/CANBridge/pull/29).

Please note that this PR is still a work-in-progress; while we have successfully ran a local build of the REV Hardware Client that was able to load and initialize the CAN backend, we are still in the process of testing with real hardware to ensure full functionality (and no regressions) on all 3 OSes.  We are opening this PR in the current state in order to gather feedback and make sure we do the changes in a way acceptable to having the PR merged upstream (once completed, of course).