### PR TITLE
Allow receiveMessage() to return undefined

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -49,7 +49,7 @@ export class CanBridge {
     getDevices: () => Promise<CanDeviceInfo[]>;
     registerDeviceToHAL: (descriptor:string, messageId:Number, messageMask:number) => number;
     unregisterDeviceFromHAL: (descriptor:string) => Promise<number>;
-    receiveMessage: (descriptor:string, messageId:number, messageMask:number) => CanMessage;
+    receiveMessage: (descriptor:string, messageId:number, messageMask:number) => CanMessage | undefined;
     openStreamSession: (descriptor:string, messageId:number, messageMask:number, maxSize:number) => number;
     readStreamSession: (descriptor:string, sessionHandle:number, messagesToRead:number) => CanMessage[];
     closeStreamSession: (descriptor:string, sessionHandle:number) => number;


### PR DESCRIPTION
This is a draft because it's a breaking change, and we don't want to merge this until we're ready to release a new major version