### PR TITLE
Add method to send RTR frame

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -33,9 +33,6 @@ export enum ThreadPriority {
     PriorityError
 }
 
-// Needs to match HAL_CAN_IS_FRAME_REMOTE
-export const RTR_FRAME_BIT = 0x80000000;
-
 let bindingOptions = require("../binding-options.cjs");
 
 export class CanBridgeInitializationError extends Error {

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -56,6 +56,7 @@ export class CanBridge {
     readStreamSession: (descriptor:string, sessionHandle:number, messagesToRead:number) => CanMessage[];
     closeStreamSession: (descriptor:string, sessionHandle:number) => number;
     getCANDetailStatus: (descriptor:string) => CanDeviceStatus;
+    sendRtrMessage: (descriptor:string, messageId: number, messageData: number[], repeatPeriod: number) => number;
     sendCANMessage: (descriptor:string, messageId: number, messageData: number[], repeatPeriod: number) => number;
     sendHALMessage: (messageId: number, messageData: number[], repeatPeriod: number) => number;
     initializeNotifier: () => void;
@@ -83,6 +84,7 @@ export class CanBridge {
             this.readStreamSession = addon.readStreamSession;
             this.closeStreamSession = addon.closeStreamSession;
             this.getCANDetailStatus = addon.getCANDetailStatus;
+            this.sendRtrMessage = addon.sendRtrMessage;
             this.sendCANMessage = addon.sendCANMessage;
             this.sendHALMessage = addon.sendHALMessage;
             this.initializeNotifier = addon.initializeNotifier;

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -20,6 +20,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, getCANDetailStatus));
     exports.Set(Napi::String::New(env, "sendCANMessage"),
                 Napi::Function::New(env, sendCANMessage));
+    exports.Set(Napi::String::New(env, "sendRtrMessage"),
+        Napi::Function::New(env, sendRtrMessage));
     exports.Set(Napi::String::New(env, "sendHALMessage"),
                 Napi::Function::New(env, sendHALMessage));
     exports.Set(Napi::String::New(env, "initializeNotifier"),

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -515,6 +515,34 @@ Napi::Number sendCANMessage(const Napi::CallbackInfo& info) {
     return Napi::Number::New(env, status);
 }
 
+
+// Params:
+//   descriptor: string
+//   messageId: Number
+//   messageData: Number[]
+//   repeatPeriod: Number
+// Returns:
+//   status: Number
+Napi::Number sendRtrMessage(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    std::string descriptor = info[0].As<Napi::String>().Utf8Value();
+    uint32_t messageId = info[1].As<Napi::Number>().Uint32Value();
+    Napi::Array dataParam = info[2].As<Napi::Array>();
+    int repeatPeriodMs = info[3].As<Napi::Number>().Uint32Value();
+
+    messageId |= HAL_CAN_IS_FRAME_REMOTE;
+
+    uint8_t messageData[8];
+    for (uint32_t i = 0; i < dataParam.Length(); i++) {
+        messageData[i] = dataParam.Get(i).As<Napi::Number>().Uint32Value();
+    }
+    int status = _sendCANMessage(descriptor, messageId, messageData, dataParam.Length(), repeatPeriodMs);
+    if (status < 0) {
+        Napi::Error::New(env, DEVICE_NOT_FOUND_ERROR).ThrowAsJavaScriptException();
+    }
+    return Napi::Number::New(env, status);
+}
+
 // Params:
 //   descriptor: string
 //   messageId: Number

--- a/src/canWrapper.h
+++ b/src/canWrapper.h
@@ -12,6 +12,7 @@ Napi::Array readStreamSession(const Napi::CallbackInfo& info);
 Napi::Number closeStreamSession(const Napi::CallbackInfo& info);
 Napi::Object getCANDetailStatus(const Napi::CallbackInfo& info);
 Napi::Number sendCANMessage(const Napi::CallbackInfo& info);
+Napi::Number sendRtrMessage(const Napi::CallbackInfo& info);
 Napi::Number sendCANMessageThroughHal(const Napi::CallbackInfo& info);
 Napi::Number sendHALMessage(const Napi::CallbackInfo& info);
 void initializeNotifier(const Napi::CallbackInfo& info);


### PR DESCRIPTION
To tell the library to send an RTR, the highest bit needs to be set. JS converts to signed int32 for bitmath (bitmath on signed values 🤮), so we want to do this in C++. This PR also removes the JS constant so no one is tempted to try it.