### PR TITLE
Add getLatestMessageOfEveryReceivedArbId() function

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -75,9 +75,9 @@ export class CanBridge {
     stopHeartbeats: (descriptor: string, sendDisabledHeartbeatsFirst: boolean) => void;
     ackHeartbeats: () => void;
     /**
-     * @return Object that maps arbitration IDs to the timestamp a message with that ID was last received at
+     * @return Object that maps arbitration IDs to the last-received message with that ID
      */
-    getTimestampsForAllReceivedMessages: (descriptor: string) => Record<number, number>;
+    getLatestMessageOfEveryReceivedArbId: (descriptor: string) => Record<number, CanMessage>;
 
     constructor() {
         try {
@@ -107,7 +107,7 @@ export class CanBridge {
             this.startRevCommonHeartbeat = addon.startRevCommonHeartbeat;
             this.ackHeartbeats = addon.ackHeartbeats;
             this.stopHeartbeats = addon.stopHeartbeats;
-            this.getTimestampsForAllReceivedMessages = addon.getTimestampsForAllReceivedMessages;
+            this.getLatestMessageOfEveryReceivedArbId = addon.getLatestMessageOfEveryReceivedArbId;
         } catch (e: any) {
             throw new CanBridgeInitializationError(e);
         }

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -74,6 +74,10 @@ export class CanBridge {
     startRevCommonHeartbeat: (descriptor: string) => void;
     stopHeartbeats: (descriptor: string, sendDisabledHeartbeatsFirst: boolean) => void;
     ackHeartbeats: () => void;
+    /**
+     * @return Object that maps arbitration IDs to the timestamp a message with that ID was last received at
+     */
+    getTimestampsForAllReceivedMessages: (descriptor: string) => Record<number, number>;
 
     constructor() {
         try {
@@ -103,30 +107,9 @@ export class CanBridge {
             this.startRevCommonHeartbeat = addon.startRevCommonHeartbeat;
             this.ackHeartbeats = addon.ackHeartbeats;
             this.stopHeartbeats = addon.stopHeartbeats;
+            this.getTimestampsForAllReceivedMessages = addon.getTimestampsForAllReceivedMessages;
         } catch (e: any) {
             throw new CanBridgeInitializationError(e);
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -77,7 +77,7 @@ export class CanBridge {
     /**
      * @return Object that maps arbitration IDs to the last-received message with that ID
      */
-    getLatestMessageOfEveryReceivedArbId: (descriptor: string) => Record<number, CanMessage>;
+    getLatestMessageOfEveryReceivedArbId: (descriptor: string, maxAgeMs: number) => Record<number, CanMessage>;
 
     constructor() {
         try {

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -3,7 +3,7 @@ import * as path from "path";
 import axios from 'axios';
 import AdmZip from 'adm-zip';
 
-const canBridgeTag = "v2.5.1";
+const canBridgeTag = "v2.6.0";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/REVrobotics/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -50,6 +50,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, stopHeartbeats));
     exports.Set(Napi::String::New(env, "ackHeartbeats"),
                 Napi::Function::New(env, ackHeartbeats));
+    exports.Set(Napi::String::New(env, "getTimestampsForAllReceivedMessages"),
+                Napi::Function::New(env, getTimestampsForAllReceivedMessages));
     return exports;
 }
 

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -50,8 +50,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, stopHeartbeats));
     exports.Set(Napi::String::New(env, "ackHeartbeats"),
                 Napi::Function::New(env, ackHeartbeats));
-    exports.Set(Napi::String::New(env, "getTimestampsForAllReceivedMessages"),
-                Napi::Function::New(env, getTimestampsForAllReceivedMessages));
+    exports.Set(Napi::String::New(env, "getLatestMessageOfEveryReceivedArbId"),
+                Napi::Function::New(env, getLatestMessageOfEveryReceivedArbId));
     return exports;
 }
 

--- a/src/canWrapper.h
+++ b/src/canWrapper.h
@@ -28,5 +28,5 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info);
 void startRevCommonHeartbeat(const Napi::CallbackInfo& info);
 void stopHeartbeats(const Napi::CallbackInfo& info);
 void ackHeartbeats(const Napi::CallbackInfo& info);
-Napi::Object getTimestampsForAllReceivedMessages(const Napi::CallbackInfo& info);
+Napi::Object getLatestMessageOfEveryReceivedArbId(const Napi::CallbackInfo& info);
 #endif

--- a/src/canWrapper.h
+++ b/src/canWrapper.h
@@ -28,4 +28,5 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info);
 void startRevCommonHeartbeat(const Napi::CallbackInfo& info);
 void stopHeartbeats(const Napi::CallbackInfo& info);
 void ackHeartbeats(const Napi::CallbackInfo& info);
+Napi::Object getTimestampsForAllReceivedMessages(const Napi::CallbackInfo& info);
 #endif


### PR DESCRIPTION
@doleksy, the `Napi` types come from this library, used to write native node.js addons in C++: https://github.com/nodejs/node-addon-api/

@LandryNorris This uses https://github.com/REVrobotics/CANBridge/pull/41, which is small enough that I was comfortable merging with only Dave's approval, but you should at least look at what it does.

The goal here is to help me reliably determine what devices are on the bus in a manner that is both bulletproof and performant.