### PR TITLE
Link libraries and the MSVC CRT statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include_directories(${NODE_ADDON_API_DIR} ${CMAKE_JS_INC} ${CMAKE_CURRENT_SOURCE
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
-target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} CANBridge wpiHal wpiutil)
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} CANBridge-static wpiHal wpiutil)
 
 target_link_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/externalCompileTimeDeps)
 
@@ -68,11 +68,17 @@ target_link_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/prebu
 target_link_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-linux-arm32)
 target_link_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-darwin-osxuniversal)
 
+# Link against Visual C++ CRT statically
+if(WIN32)
+    target_compile_options(${PROJECT_NAME} PUBLIC /MT)
+endif()
+
 include(move-files.cmake)
 
+# TODO: Delete this whole section once we're linking against all libraries statically
 foreach(CONFIG_TYPE IN LISTS CMAKE_CONFIGURATION_TYPES)
     # Windows
-    create_move_target(CANBridge.dll ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-win32-x64/CANBridge.dll ${CONFIG_TYPE}/CANBridge.dll)
+    # create_move_target(CANBridge.dll ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-win32-x64/CANBridge.dll ${CONFIG_TYPE}/CANBridge.dll)
     create_move_target(wpiHal.dll ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-win32-x64/wpiHal.dll ${CONFIG_TYPE}/wpiHal.dll)
     create_move_target(wpiUtil.dll ${CMAKE_CURRENT_SOURCE_DIR}/prebuilds/node_canbridge-win32-x64/wpiUtil.dll ${CONFIG_TYPE}/wpiUtil.dll)
 

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -12,8 +12,9 @@ const tempDir = 'temp';
 
 try {
     await Promise.all(Array.of(
-        downloadCanBridgeArtifact('CANBridge.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('CANBridge.dll', runtimeArtifactsPath),
+        downloadCanBridgeArtifact('CANBridge-static.lib', externalCompileTimeDepsPath),
+        // TODO: Download static versions of wpiHal and wpiutil
+        //       (consider merging https://github.com/REVrobotics/CANBridge/pull/37)
         downloadCanBridgeArtifact('wpiHal.lib', externalCompileTimeDepsPath),
         downloadCanBridgeArtifact('wpiHal.dll', runtimeArtifactsPath),
         downloadCanBridgeArtifact('wpiutil.lib', externalCompileTimeDepsPath),


### PR DESCRIPTION
This PR is blocked by changes needed from https://github.com/REVrobotics/CANBridge:
* Even the static build of CANBridge is built using the `/MD` compiler option instead of `/MT`, so it still requires a compatible version of the Visual C++ Redistributable to be installed
	* After building `CANBridge`, you can see the compiler options used at `build/tmp/compileCANBridgeWindowsx86-64ReleaseStaticLibraryCANBridgeCpp/options.txt`
* Once we prove the concept by using manually-extracted static WPILib artifacts from [here](https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/2023.4.3/wpiutil-cpp-2023.4.3-windowsx86-64static.zip) and [here](https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/2023.4.3/hal-cpp-2023.4.3-windowsx86-64static.zip), we should merge https://github.com/REVrobotics/CANBridge/pull/37, as that already contains changes to upload all of the static libraries we'll need to future CANBridge releases.